### PR TITLE
Add TFlite model for YOLOv8n

### DIFF
--- a/app/src/main/java/datasetcolab/App.java
+++ b/app/src/main/java/datasetcolab/App.java
@@ -547,7 +547,10 @@ public class App {
 
                 String model = ctx.pathParam("model");
                 String fileName = "";
-                if (model.startsWith("YOLO")) {
+                if (model == "YOLOv8n") {
+                    fileName = "models/" + model + "/" + model + ctx.queryParam("downloadType") + (ctx.queryParam("downloadType") == "" ? ".pt" : ".zip");
+                }
+                else if (model.startsWith("YOLO")) {
                     fileName = "models/" + model + "/weights/best.pt";
                 } else {
                     fileName = "models/" + model + "/" + model + ctx.queryParam("downloadType") + ".zip";

--- a/website/src/pages/PretrainedModels.js
+++ b/website/src/pages/PretrainedModels.js
@@ -64,7 +64,7 @@ export default function PretrainedModels() {
     const [showCopyAlert, setShowCopyAlert] = useState(false);
 
     const [datasets, setDatasets] = useState([
-        { name: "YOLOv8", dataset: "FRC 2024", model: "YOLOv8n", variants: ["YOLOv8n", "YOLOv8s"], classes: ["note", "robot"], download: "direct" },
+        { name: "YOLOv8", dataset: "FRC 2024", model: "YOLOv8n", variants: ["YOLOv8n", "YOLOv8s"], downloadType: "PyTorch", downloadTypes: ["PyTorch", "TFLite"], classes: ["note", "robot"], download: "direct" },
         { name: "YOLOv6", dataset: "FRC 2024", model: "YOLOv6n", variants: ["YOLOv6n", "YOLOv6s"], classes: ["note", "robot"], download: "direct" },
         { name: "YOLOv5", dataset: "FRC 2024", model: "YOLOv5n", variants: ["YOLOv5n", "YOLOv5s"], classes: ["note", "robot"], download: "direct" },
         { name: "SSD Mobilenet v2", dataset: "FRC 2024", model: "ssdmobilenet", downloadType: "TFLite", downloadTypes: ["TFLite", "Tensorflow"], classes: ["note", "robot"], download: "direct" },
@@ -293,7 +293,12 @@ export default function PretrainedModels() {
         if (dataset.model === "efficientdet" || dataset.model === "ssdmobilenet") {
             downloadType = dataset.downloadType === "Tensorflow" ? "TF" : "TFLite";
             fileType = ".zip";
-        } else {
+        }
+        if (dataset.model === "YOLOv8n") {
+            downloadType = dataset.downloadType === "PyTorch" ? "" : "TFLite";
+            fileType = downloadType === "TFLite" ? ".zip" : ".pt";
+        }
+        else {
             fileType = ".pt";
         }
 


### PR DESCRIPTION
Hi,

I converted the YOLOv8n model to Edge TPU following [this guide](https://docs.ultralytics.com/guides/coral-edge-tpu-on-raspberry-pi/). It works on the Limelight, so I think it would be a good thing to include in Dataset Colab.

Here is the model for notes only: [https://drive.google.com/drive/folders/19TXyOEJFwhulZMrmd4C_8X4WnwHBjvup?usp=drive_link](https://drive.google.com/drive/folders/19TXyOEJFwhulZMrmd4C_8X4WnwHBjvup?usp=drive_link)
Both: [https://drive.google.com/drive/folders/1WQLCasXQHPjmxE2txSBkLR-YphlnOKte?usp=drive_link](https://drive.google.com/drive/folders/1WQLCasXQHPjmxE2txSBkLR-YphlnOKte?usp=drive_link)
Robot only: [https://drive.google.com/drive/folders/1XUU4oQw-UEhFKmPcDHomVZAGHKY2VkQ5?usp=drive_link](https://drive.google.com/drive/folders/1XUU4oQw-UEhFKmPcDHomVZAGHKY2VkQ5?usp=drive_link)

I've rescaled the image input to 224x224 to play nicely with the Edge TPU.